### PR TITLE
Fixing typo APPLICATION_INSIGHTS to APPLICATIONINSIGHTS

### DIFF
--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -34,7 +34,7 @@ resource "azurerm_linux_function_app" "example" {
   }
 
   app_settings = {
-    APPLICATIONINSIGHTS_CONNECTION_STRING                = azurerm_application_insights.example[each.key].connection_string
+    APPLICATIONINSIGHTS_CONNECTION_STRING                 = azurerm_application_insights.example[each.key].connection_string
     BUILD_FLAGS                                           = "UseExpressBuild"
     ENABLE_ORYX_BUILD                                     = true
     sboxdlrmeventhubns_RootManageSharedAccessKey_EVENTHUB = data.azurerm_eventhub_namespace_authorization_rule.lz[each.value.lz_key].primary_connection_string

--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -34,7 +34,7 @@ resource "azurerm_linux_function_app" "example" {
   }
 
   app_settings = {
-    APPLICATION_INSIGHTS_CONNECTION_STRING                = azurerm_application_insights.example[each.key].connection_string
+    APPLICATIONINSIGHTS_CONNECTION_STRING                = azurerm_application_insights.example[each.key].connection_string
     BUILD_FLAGS                                           = "UseExpressBuild"
     ENABLE_ORYX_BUILD                                     = true
     sboxdlrmeventhubns_RootManageSharedAccessKey_EVENTHUB = data.azurerm_eventhub_namespace_authorization_rule.lz[each.value.lz_key].primary_connection_string


### PR DESCRIPTION
fixing typo as described in title.
<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
