### PR TITLE
Adding LinuxFxVersion as Python3.9

### DIFF
--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -30,8 +30,7 @@ resource "azurerm_linux_function_app" "example" {
   storage_account_access_key = data.azurerm_storage_account.xcutting[each.value.lz_key].primary_access_key
 
   site_config {
-    always_on        = false
-    linux_fx_version = "Python|3.11"
+    always_on = false
   }
 
   app_settings = {
@@ -43,6 +42,7 @@ resource "azurerm_linux_function_app" "example" {
     sboxdlrmeventhubns_RootManageSharedAccessKey_EVENTHUB = data.azurerm_eventhub_namespace_authorization_rule.lz[each.value.lz_key].primary_connection_string
     SCM_DO_BUILD_DURING_DEPLOYMENT                        = 1
     XDG_CACHE_HOME                                        = "/tmp/.cache"
+    WEBSITE_RUN_FROM_PACKAGE                              = "1"
   }
 
   tags = module.ctags.common_tags

--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -31,7 +31,7 @@ resource "azurerm_linux_function_app" "example" {
 
   site_config {
     always_on = false
-
+    LinuxFxVersion = "Python|3.9"
   }
 
   app_settings = {

--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -30,8 +30,8 @@ resource "azurerm_linux_function_app" "example" {
   storage_account_access_key = data.azurerm_storage_account.xcutting[each.value.lz_key].primary_access_key
 
   site_config {
-    always_on      = false
-    LinuxFxVersion = "Python|3.9"
+    always_on        = false
+    linux_fx_version = "Python|3.11"
   }
 
   app_settings = {

--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -30,7 +30,7 @@ resource "azurerm_linux_function_app" "example" {
   storage_account_access_key = data.azurerm_storage_account.xcutting[each.value.lz_key].primary_access_key
 
   site_config {
-    always_on = false
+    always_on      = false
     LinuxFxVersion = "Python|3.9"
   }
 


### PR DESCRIPTION
Adding LinuxFxVersion as code deployment is not working until this parameter is defined.

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
