### PR TITLE
Using 1:1 storage account before using xcutting

### DIFF
--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -27,8 +27,8 @@ resource "azurerm_linux_function_app" "example" {
   resource_group_name        = data.azurerm_resource_group.lz["ingest${each.value.lz_key}-main-${var.env}"].name
   location                   = data.azurerm_resource_group.lz["ingest${each.value.lz_key}-main-${var.env}"].location
   service_plan_id            = azurerm_service_plan.example[each.key].id
-  storage_account_name       = data.azurerm_storage_account.xcutting[each.value.lz_key].name               #azurerm_storage_account.example[each.key].name               
-  storage_account_access_key = data.azurerm_storage_account.xcutting[each.value.lz_key].primary_access_key #azurerm_storage_account.example[each.key].primary_access_key 
+  storage_account_name       = azurerm_storage_account.example[each.key].name               # data.azurerm_storage_account.xcutting[each.value.lz_key].name                        
+  storage_account_access_key = azurerm_storage_account.example[each.key].primary_access_key #data.azurerm_storage_account.xcutting[each.value.lz_key].primary_access_key 
 
   app_settings = {
     APPLICATIONINSIGHTS_CONNECTION_STRING                 = azurerm_application_insights.example[each.key].connection_string


### PR DESCRIPTION


- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
