### PR TITLE
Test apply to recreate storage blob reader/contributor in 00,01,02 sbox

### DIFF
--- a/components/aria-layer/access_policy.tf
+++ b/components/aria-layer/access_policy.tf
@@ -39,7 +39,7 @@ resource "azurerm_role_assignment" "rbac_write" {
     ]) : combo.key => combo
   }
 
-  # Assign scope per LZ, use current_config as run in CICD, giving SP the permissions required for Databricks       NOTE KEYVAULT ADMIN TOO
+  # Assign scope per LZ, use current_config as run in CICD, giving SP the permissions required for Databricks
   scope = {
     "landing"  = data.azurerm_storage_account.landing[each.value.lz_key].id
     "curated"  = data.azurerm_storage_account.curated[each.value.lz_key].id

--- a/components/aria-layer/key_vault.tf
+++ b/components/aria-layer/key_vault.tf
@@ -106,3 +106,21 @@ resource "azurerm_key_vault_secret" "client_secret_copy" {
 
   tags = module.ctags.common_tags
 }
+
+# Backup: add in KV admin privilidges to the SP
+
+resource "azurerm_role_assignment" "kv_admin" {
+  for_each = var.landing_zones
+
+  scope                = data.azurerm_key_vault.logging_vault[each.key].id
+  role_definition_name = "Key Vault Administrator"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_role_assignment" "kv_officer" {
+  for_each = var.landing_zones
+
+  scope                = data.azurerm_key_vault.logging_vault[each.key].id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}


### PR DESCRIPTION
Previous role assignments already existed. Deleted in the UI. To recreate via TF

Also testing creation of sudo client secret using CS-SP1. To update in next applyPR

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
