### PR TITLE
Update  xcutting storage account to have soft delete on blobs (365 da…

### DIFF
--- a/components/aria-layer/eventhubs.tf
+++ b/components/aria-layer/eventhubs.tf
@@ -61,8 +61,8 @@ resource "azurerm_eventhub" "aria_active_topic" {
 module "active_case_link_eventhubs" {
   source = "../../modules/active-eventhubs"
 
-  env = var.env
-  evh_name = "active-caselink"  # "evh-${var.evh_name}-${suffix}-${var.env}-${lz_key}-uks-dlrm-01"
+  env      = var.env
+  evh_name = "active-caselink" # "evh-${var.evh_name}-${suffix}-${var.env}-${lz_key}-uks-dlrm-01"
   landing_zones = {
     for lz_key in keys(var.landing_zones) : lz_key => {
       eventhub_namespace_name                = data.azurerm_eventhub_namespace.lz[lz_key].name

--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -30,16 +30,12 @@ resource "azurerm_storage_account" "xcutting" {
     virtual_network_subnet_ids = []      #data.azurerm_subnet.lz["ingest${each.key}-data-product-001-${var.env}"].id] 
   }
 
-    blob_properties {
-    delete_retention_policy {
-      enabled = true
-      days    = 365
-    }
+  delete_retention_policy {
+    days = 365
   }
 
   container_delete_retention_policy {
-    days    = 7 
-    enabled = true
+    days = 7
   }
 
   tags = module.ctags.common_tags

--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -30,6 +30,18 @@ resource "azurerm_storage_account" "xcutting" {
     virtual_network_subnet_ids = []      #data.azurerm_subnet.lz["ingest${each.key}-data-product-001-${var.env}"].id] 
   }
 
+    blob_properties {
+    delete_retention_policy {
+      enabled = true
+      days    = 365
+    }
+  }
+
+  container_delete_retention_policy {
+    days    = 7 
+    enabled = true
+  }
+
   tags = module.ctags.common_tags
 }
 

--- a/components/aria-layer/function_app.tf
+++ b/components/aria-layer/function_app.tf
@@ -30,12 +30,14 @@ resource "azurerm_storage_account" "xcutting" {
     virtual_network_subnet_ids = []      #data.azurerm_subnet.lz["ingest${each.key}-data-product-001-${var.env}"].id] 
   }
 
-  delete_retention_policy {
-    days = 365
-  }
+  blob_properties {
+    delete_retention_policy {
+      days = 365
+    }
 
-  container_delete_retention_policy {
-    days = 7
+    container_delete_retention_policy {
+      days = 7
+    }
   }
 
   tags = module.ctags.common_tags

--- a/components/aria-layer/locals.tf
+++ b/components/aria-layer/locals.tf
@@ -27,8 +27,8 @@ locals {
     "af-bails",
     "af-joh",
     "af-td",
-    "af-active-ccd",  # Active Azure Function APP
-    "af-active-caselink-ccd"  # Active Azure Function APP for case linking
+    "af-active-ccd",         # Active Azure Function APP
+    "af-active-caselink-ccd" # Active Azure Function APP for case linking
   ]
 
 


### PR DESCRIPTION
…ys_ and on containers (7 days)

Required change is detailed https://tools.hmcts.net/jira/browse/ARIADM-2018. Only xcutting does not have soft delete as it is a Storage Account we manage in our own TF. landing,curated, etc allow for 365 days blob soft deletion and 7 day container soft deletion