### PR TITLE
Setting min pools default to 0

### DIFF
--- a/components/aria-layer/variables.tf
+++ b/components/aria-layer/variables.tf
@@ -51,5 +51,5 @@ variable "max_capacity" {
 variable "min_capacity" {
   description = "Min total instances in the pool"
   type        = number
-  default     = 26
+  default     = 0
 }


### PR DESCRIPTION
This is so idle pools do not take up IP space in the subnets and cost money to keep excess VMs active.